### PR TITLE
specify encoding when updating the dataset

### DIFF
--- a/R/data_refresh.R
+++ b/R/data_refresh.R
@@ -27,6 +27,7 @@ update_dataset <- function(silence = FALSE){
 
 
   coronavirus_git <- utils::read.csv("https://raw.githubusercontent.com/RamiKrispin/coronavirus/master/csv/coronavirus.csv",
+                                     fileEncoding = "UTF-8",
                                      stringsAsFactors = FALSE)
 
 


### PR DESCRIPTION
Dear Rami Krispin!


Thanks for your awesome `coronavirus`-package, it makes working with Covid-19-data in R very convenient!


Never the less I had an issue: I wasn't able to update the dataset on my machine (running a `Debian Stable`-based OS and `R 3.5.2`) because I was getting the following error:

```
invalid multibyte string at '<f0><8a><cb><fa>'
```

When looking into the `update_dataset()`-function (in the `R/data_refresh.R`-file) I realized that this will probably be due to the `read.csv()`-function.  When running `rio::import()` on the same target (which uses `data.table::fread()` by default) this issue disappeared. I assumed that the error had to do with the encoding, which is why I specified the additional option `fileEndocing = "UTF-8"` inside the `read.csv()`-function, which solved the problem.


Since I assume that other people might also have that issue as well, I'm submitting this pull request with only this single line added.


If you have any questions don't hesitate to write me.


Best wishes, Alex (life science PhD-student from Vienna, Austria)

-----

ps.: an excerpt of my `utils::sessionInfo()`-data looks as following:

```
R version 3.5.2 (2018-12-20)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: PureOS

locale:
 [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C
 [3] LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8
 [5] LC_MONETARY=de_DE.UTF-8    LC_MESSAGES=en_US.UTF-8
 [7] LC_PAPER=en_US.UTF-8       LC_NAME=C
 [9] LC_ADDRESS=C               LC_TELEPHONE=C
[11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C
```